### PR TITLE
Split the single DownloadListener.onChange() method into multiple methods.

### DIFF
--- a/filedownloader/src/androidTest/java/com/everardo/filedownloader/FileDownloaderIntegrationTest.kt
+++ b/filedownloader/src/androidTest/java/com/everardo/filedownloader/FileDownloaderIntegrationTest.kt
@@ -135,8 +135,8 @@ class FileDownloaderIntegrationTest {
 
         fileDownloader.uri(Uri.parse("https://www.google.com"))
                 .fileName("file1")
-                .listener(object: DownloadListener {
-                    override fun onChange(status: StatusEvent) {
+                .listener(object: AbstractDownloadListener() {
+                    override fun onCompleted(status: StatusEvent) {
                         assertEquals("file1", status.fileName)
                         assertEquals(Status.COMPLETED, status.status)
                         assertEquals(1.0, status.progress, 0.05)
@@ -148,8 +148,8 @@ class FileDownloaderIntegrationTest {
 
         fileDownloader.uri(Uri.parse("https://www.google.com/subpath"))
                 .fileName("file2")
-                .listener(object: DownloadListener {
-                    override fun onChange(status: StatusEvent) {
+                .listener(object: AbstractDownloadListener() {
+                    override fun onError(status: StatusEvent) {
                         assertEquals("file2", status.fileName)
                         assertEquals(Status.ERROR, status.status)
                         assertEquals(0.5, status.progress, 0.05)

--- a/filedownloader/src/androidTest/java/com/everardo/filedownloader/NotifierTest.kt
+++ b/filedownloader/src/androidTest/java/com/everardo/filedownloader/NotifierTest.kt
@@ -96,8 +96,9 @@ class NotifierTest {
         val latch = CountDownLatch(1)
         var listenerInvokedTimes = 0
 
-        val listener = object: DownloadListener {
-            override fun onChange(status: StatusEvent) {
+        val listener = object: AbstractDownloadListener() {
+
+            override fun onProgress(status: StatusEvent) {
                 listenerInvokedTimes++
 
                 assertEquals(token, status.token)
@@ -133,8 +134,9 @@ class NotifierTest {
         val latch = CountDownLatch(2)
         var listenerInvokedTimes = 0
 
-        val listener = object: DownloadListener {
-            override fun onChange(status: StatusEvent) {
+        val listener = object: AbstractDownloadListener() {
+
+            override fun onProgress(status: StatusEvent) {
                 listenerInvokedTimes++
 
                 assertEquals(Status.IN_PROGRESS, status.status)
@@ -145,8 +147,9 @@ class NotifierTest {
             }
         }
 
-        val listener2 = object: DownloadListener {
-            override fun onChange(status: StatusEvent) {
+        val listener2 = object: AbstractDownloadListener() {
+
+            override fun onCompleted(status: StatusEvent) {
                 listenerInvokedTimes++
 
                 assertEquals(Status.COMPLETED, status.status)
@@ -178,8 +181,29 @@ class NotifierTest {
         val latch = CountDownLatch(1)
         var listenerInvokedTimes = 0
 
-        val listener = object: DownloadListener {
-            override fun onChange(status: StatusEvent) {
+        val listener = object: AbstractDownloadListener() {
+
+            override fun onCancelled(status: StatusEvent) {
+                listenerInvokedTimes++
+                latch.countDown()
+            }
+
+            override fun onCompleted(status: StatusEvent) {
+                listenerInvokedTimes++
+                latch.countDown()
+            }
+
+            override fun onError(status: StatusEvent) {
+                listenerInvokedTimes++
+                latch.countDown()
+            }
+
+            override fun onPending(status: StatusEvent) {
+                listenerInvokedTimes++
+                latch.countDown()
+            }
+
+            override fun onProgress(status: StatusEvent) {
                 listenerInvokedTimes++
                 latch.countDown()
             }

--- a/filedownloader/src/main/java/com/everardo/filedownloader/DownloadListener.kt
+++ b/filedownloader/src/main/java/com/everardo/filedownloader/DownloadListener.kt
@@ -1,5 +1,17 @@
 package com.everardo.filedownloader
 
 interface DownloadListener {
-    fun onChange(status: StatusEvent)
+    fun onPending(status: StatusEvent)
+    fun onCompleted(status: StatusEvent)
+    fun onProgress(status: StatusEvent)
+    fun onCancelled(status: StatusEvent)
+    fun onError(status: StatusEvent)
+}
+
+abstract class AbstractDownloadListener : DownloadListener {
+    override fun onPending(status: StatusEvent) {}
+    override fun onCompleted(status: StatusEvent) {}
+    override fun onProgress(status: StatusEvent) {}
+    override fun onCancelled(status: StatusEvent) {}
+    override fun onError(status: StatusEvent) {}
 }

--- a/filedownloader/src/main/java/com/everardo/filedownloader/Notifier.kt
+++ b/filedownloader/src/main/java/com/everardo/filedownloader/Notifier.kt
@@ -61,7 +61,13 @@ internal class NotifierImpl(private val context: Context, private val fileDownlo
                 val statusEvent = with(dataStatusChange) {
                     StatusEvent(status, token, progress, fileDownloader, token.uri, token.fileName, error)
                 }
-                it.onChange(statusEvent)
+                when (statusEvent.status) {
+                    Status.PENDING -> it.onPending(statusEvent)
+                    Status.COMPLETED -> it.onCompleted(statusEvent)
+                    Status.IN_PROGRESS -> it.onProgress(statusEvent)
+                    Status.CANCELLED -> it.onCancelled(statusEvent)
+                    Status.ERROR -> it.onError(statusEvent)
+                }
             }
         }
     }

--- a/filedownloader/src/test/java/com/everardo/filedownloader/ApiDesignTest.java
+++ b/filedownloader/src/test/java/com/everardo/filedownloader/ApiDesignTest.java
@@ -108,17 +108,17 @@ public class ApiDesignTest {
                 DownloadToken token = new DownloadToken(mock(Uri.class), "some", "any");
                 DownloadListener listener = invocation.getArgument(2);
                 StatusEvent response = new StatusEvent(Status.COMPLETED, token, 1.0, fileDownloader, uri, fileName, null);
-                listener.onChange(response);
+                listener.onCompleted(response);
 
                 return token;
             }
         }).when(fileDownloader).download(any(Uri.class), anyString(), any(DownloadListener.class), anyLong(), any(File.class));
 
 
-        DownloadListener testListener = new DownloadListener() {
+        DownloadListener testListener = new AbstractDownloadListener() {
 
             @Override
-            public void onChange(@NotNull StatusEvent status) {
+            public void onCompleted(@NotNull StatusEvent status) {
                 assertEquals(Status.COMPLETED, status.getStatus());
                 assertEquals(1.0, status.getProgress(), 0.05);
             }
@@ -146,17 +146,17 @@ public class ApiDesignTest {
                 DownloadListener listener = invocation.getArgument(2);
                 Error error = new Error(Error.Code.HTTP_ERROR, 400);
                 StatusEvent response = new StatusEvent(Status.ERROR, token, 1.0, fileDownloader, uri, fileName, error);
-                listener.onChange(response);
+                listener.onError(response);
 
                 return token;
             }
         }).when(fileDownloader).download(any(Uri.class), anyString(), any(DownloadListener.class), anyLong(), any(File.class));
 
 
-        DownloadListener testListener = new DownloadListener() {
+        DownloadListener testListener = new AbstractDownloadListener() {
 
             @Override
-            public void onChange(@NotNull StatusEvent status) {
+            public void onError(@NotNull StatusEvent status) {
                 assertEquals(Status.ERROR, status.getStatus());
 
                 Error error = status.getError();
@@ -188,22 +188,25 @@ public class ApiDesignTest {
     public void cancel() {
         final String fileName = "myfile";
 
-        final DownloadListener testListener = new DownloadListener() {
+        final DownloadListener testListener = new AbstractDownloadListener() {
 
             @Override
-            public void onChange(@NotNull StatusEvent status) {
-                if (Status.IN_PROGRESS == status.getStatus()) {
-                    assertNotEquals(0, status.getProgress(), 0.05);
-                } else {
+            public void onProgress(@NotNull StatusEvent status) {
+                assertEquals(Status.IN_PROGRESS, status.getStatus());
+                assertNotEquals(0, status.getProgress(), 0.05);
+            }
 
-                    assertEquals(Status.CANCELLED, status.getStatus());
+            @Override
+            public void onCancelled(@NotNull StatusEvent status) {
+                super.onCancelled(status);
 
-                    // retry
-                    status.getDownloader().uri(status.getUri())
-                            .fileName(status.getFileName())
-                            .listener(this)
-                            .download();
-                }
+                assertEquals(Status.CANCELLED, status.getStatus());
+
+                // retry
+                status.getDownloader().uri(status.getUri())
+                        .fileName(status.getFileName())
+                        .listener(this)
+                        .download();
             }
         };
 
@@ -214,7 +217,7 @@ public class ApiDesignTest {
                 DownloadToken token = new DownloadToken(mock(Uri.class), "some", "any");
                 DownloadListener listener = invocation.getArgument(2);
                 StatusEvent response = new StatusEvent(Status.IN_PROGRESS, token, 0.5, fileDownloader, uri, fileName, null);
-                listener.onChange(response);
+                listener.onProgress(response);
 
                 return token;
             }
@@ -224,7 +227,7 @@ public class ApiDesignTest {
             @Override
             public Void answer(InvocationOnMock invocation) {
                 StatusEvent response = new StatusEvent(Status.CANCELLED, mock(DownloadToken.class), 0.5, fileDownloader, uri, fileName, null);
-                testListener.onChange(response);
+                testListener.onCancelled(response);
 
                 return null;
             }
@@ -262,18 +265,17 @@ public class ApiDesignTest {
             public DownloadToken answer(InvocationOnMock invocation) throws Throwable {
                 DownloadListener listener = invocation.getArgument(2);
                 StatusEvent response = new StatusEvent(Status.COMPLETED, token, 1.0, fileDownloader, uri, fileName, null);
-                listener.onChange(response);
+                listener.onCompleted(response);
 
                 return token;
             }
         }).when(fileDownloader).download(any(Uri.class), anyString(), any(DownloadListener.class), anyLong(), any(File.class));
 
 
-        DownloadListener testListener = new DownloadListener() {
-
+        DownloadListener testListener = new AbstractDownloadListener() {
 
             @Override
-            public void onChange(@NotNull StatusEvent status) {
+            public void onCompleted(@NotNull StatusEvent status) {
                 assertEquals(Status.COMPLETED, status.getStatus());
                 assertEquals(1.0, status.getProgress(), 0.05);
             }


### PR DESCRIPTION
Split the single DownloadListener.onChange() method into multiple methods for event types. This is to avoid the clients to be overwhelmed by too many quick onProgress status changes even if they are not interested in that event. Create an Abstract implementation of DownloadListener so we can change the interface without breaking existing clients.